### PR TITLE
Fix off-by-one error in VDR

### DIFF
--- a/software/illustrative/ffmfunctions.R
+++ b/software/illustrative/ffmfunctions.R
@@ -359,9 +359,9 @@ convolve_training <- function(w, tau) {
 
 ewma_training <- function(w, tau) {
   T <- length(w)
-  if (T <= 1) return(0)
+  if (T < 1) return(0)
 
-  today_to_first_day <- T:1
+  today_to_first_day <- (T - 1):0
   first_day_to_today <- 1:T
   sum(w[first_day_to_today] * exp(-today_to_first_day / tau))
 }


### PR DESCRIPTION
Hi @bsh2 ,

Nice work finding my VDR bug. Looks like an off-by-one. I'm going to paste a modified version of your tester.R script that shows parity after this change. Note the source() statement that's calling in the `ffm_functions.R` that's in the illustrative folder.

Ben

```
loads <- data.frame("day" = 0:100,
                    "load" = c(0, rep(c(1, 1.2, 0.5, 1.8, 2, 0.25, 0.7, 0.9, 0, 0.5,
                                                       1, 0.8, 1.2, 1.3, 0.9, 0, 0, 2, 1.1, 0.5), 5) ) )

vdrPars <- c(100, 1, 25, 1.5, 6, 0.5)

convolveTraining <- function(loads, tau){

  # Convolve training loads with response function
  #
  # Args
  #   loads : Vector of load values from day 0 to t-1
  #   tau   : The tau parameter value // for tau_g or tau_h
  #
  # Returns
  #   Convolution sum: sum_(i=0)^(t-1) {w(i)e^(-(t-i)/tau)}

  # Last day in the series passed to the function
  T <- length(loads)

  # Recall loads[1:T] in this case will be from w(0) to w(T-1)
  return(sum(loads[1:T] * exp(-(T:1 / tau))))
}

kh2Compute <- function(loads, tau){
  I <- length(loads)
  return(sum(loads[1:I] * exp(- ((I-1):0 / tau))))
}

vdrPredict <- function(vdrPars, loads, initialPars = c(0,0)){

  # Function to compute sum_(i=0)^(t-1) w(i)e^(-(t-i)/tau)
  #
  # Args
  #   standardPars : Numeric parameter vector (length 5) and order c(p_star, k_g, T_g, k_h, T_h)
  #   TODO: find out if he means length6
  #   loads : Dataframe of load series values (see table 6.1, section 6.2.1)
  #   initialPars : Numeric parameter vector (length 2) and order c(q_g, q_h), default both zero
  # 
  # Returns
  #   Daily modelled performance, fitness, and fatigue over length of load inputs

  # Number of days in the training load series to predict performance for
  seriesLength <- tail(loads$day, 1)

  # If initial parameters q_g and q_h are supplied (otherwise evaluates to 0)
  initialFitness <- initialPars[1] * exp(-(1:seriesLength) / vdrPars[3])
  initialFatigue <- initialPars[2] * exp(-(1:seriesLength) / vdrPars[5])

  # Compute modeled fitness
  fitness <- vdrPars[2] *
    base::sapply(1:seriesLength, function(i) convolveTraining(loads$load[1:i], vdrPars[3]))

  # For each i=1:seriesLength, compute k_h_2(i) = sum_(j=0)^(i){w(j)e^(-(i-j)/tau_h_2)} 
  # s.t. k_h_2(t) = sum(k_h_2(i)) for i = 1,2,...,(t-1)
  kh2 <- base::sapply(1:seriesLength, function(i) kh2Compute(loads$load[1:i], vdrPars[6]))

  # Compute modeled fatigue
  fatigue <- vdrPars[4] *
    base::sapply(1:seriesLength, function(i) convolveTraining(kh2[1:i], vdrPars[5]))

  # Compute modeled performance
  performance <- vdrPars[1] + initialFitness - initialFatigue + fitness - fatigue

  # Return model predicted performance, fitness, and fatigue
  return(data.frame(day = 1:seriesLength,
                    performance = performance,
                    fitness = fitness,
                    fatigue = fatigue,
                    kh2 = kh2,
                    load = loads$load[2:(seriesLength + 1)]))
}

bsh_pred <- vdrPredict(vdrPars, loads)

library(dplyr)
source("ffmfunctions.R")
c(p_star, k_g, T_g, k_h, T_h)

df <- loads %>% rename(w = load)
df_noday0 <- df[2:nrow(df), ]  # BO's functions doesn't include a day 0 (should it?)

mod <- create_ffm_model(p_star=vdrPars[1], k_g=vdrPars[2], tau_g=vdrPars[3],
                        k_h=vdrPars[4], tau_h=vdrPars[5], tau_h2 = vdrPars[6],
                        sigma=1)
print(mod)

bo_pred <- make_predictions(mod, df_noday0$w)

# Quick check of predictions
bsh_pred %>% head()
bo_pred %>% head()

bsh_pred %>% tail()
bo_pred %>% tail()
```